### PR TITLE
Add GitHub Actions for GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: 
+     - master  
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install
+      run: npm install
+    - name: Build
+      run: npm run build
+    - name: Upload
+      uses: actions/upload-artifact@master
+      with:
+        name: app
+        path: build/
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download
+      uses: actions/download-artifact@master
+      with:
+        name: app
+        path: .
+    - name: Init
+      run: |
+        git init .
+        git config user.name ${{github.event.pusher.name}} 
+        git config user.email ${{github.event.pusher.email}}
+        git remote add origin https://x-access-token:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git
+    - name: Commit
+      run: |
+        git add .
+        git commit -m ${{github.sha}}
+    - name: Push
+      run: git push origin master:gh-pages --force


### PR DESCRIPTION
The CI code will take care of deploying latest code to the GitHub pages, where the app can be hosted from by assigning custom domain. `30minutes.lamia.tech` maybe?